### PR TITLE
Removing unused refs to django.views.generic.simple, b/c deprecated.

### DIFF
--- a/teamwork_example/base/urls.py
+++ b/teamwork_example/base/urls.py
@@ -1,5 +1,5 @@
 from django.conf.urls.defaults import *
-from django.views.generic.simple import direct_to_template
+
 
 urlpatterns = patterns('base.views',
     url(r'^$', 'index')

--- a/teamwork_example/profiles/urls.py
+++ b/teamwork_example/profiles/urls.py
@@ -1,5 +1,4 @@
 from django.conf.urls.defaults import *
-from django.views.generic.simple import direct_to_template
 import teamwork.views
 
 

--- a/teamwork_example/urls.py
+++ b/teamwork_example/urls.py
@@ -5,7 +5,6 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.shortcuts import redirect, render
 from django.views.i18n import javascript_catalog
 from django.views.decorators.cache import cache_page
-from django.views.generic.simple import direct_to_template
 
 
 admin.autodiscover()

--- a/teamwork_example/wiki/urls.py
+++ b/teamwork_example/wiki/urls.py
@@ -1,5 +1,4 @@
 from django.conf.urls.defaults import *
-from django.views.generic.simple import direct_to_template
 
 urlpatterns = patterns('wiki.views',
     url(r'^\$create$', 'create'),


### PR DESCRIPTION
Simple was used in the project & deprecated, so I removed it.

```
from django.views.generic.simple import direct_to_template
```

Afterwards I tested it with a Django upgrade to 1.5.2 & everything seemed to work. I didn't update the requirements file, because 1.5.2 was for my use case.
