### PR TITLE
Updating related name on policy.users, because 2 refs to users caused co...

### DIFF
--- a/teamwork/models.py
+++ b/teamwork/models.py
@@ -204,7 +204,7 @@ class Policy(models.Model):
     object_id = models.PositiveIntegerField()
     content_object = generic.GenericForeignKey('content_type', 'object_id')
 
-    creator = models.ForeignKey(User, null=True, blank=True)
+    creator = models.ForeignKey(User, null=True, blank=True, related_name='creator')
     team = models.ForeignKey(
         Team, db_index=True, blank=True, null=True,
         help_text='Team responsible for managing this policy')
@@ -216,7 +216,7 @@ class Policy(models.Model):
     apply_to_owners = models.BooleanField(default=False, help_text=(
         'Apply this policy to owners of content objects?'))
     users = models.ManyToManyField(
-        User, blank=True, related_name='users',
+        User, blank=True,
         help_text=('Apply this policy for these users.'))
     groups = models.ManyToManyField(Group, blank=True, help_text=(
         'Apply this policy for these user groups.'))


### PR DESCRIPTION
Creator was conflicted with Users. 

Before fix:
```
In [1]: from teamwork.models import Policy

In [2]: policy = Policy.objects.all()[0]

In [3]: policy.users.all()
Out[3]: [<User: Joe-Analyst>]

In [4]: u = policy.users.all()[0]

In [5]: u.policy_set.all()
Out[5]: []
```

After fix:
```
In [1]: from teamwork.models import Policy

In [2]: policy = Policy.objects.all()[0]

In [3]: policy.users.all()
Out[3]: [<User: Joe-Analyst>]

In [4]: u = policy.users.all()[0]

In [5]: u.policy_set.all()
Out[5]: [<Policy: Policy(Exploit CAP Imagery)>, <Policy: Policy(Exploit CAP Imagery)>]
```

Please review tests associated with this. To me it looks like it was meant to be this way in the tests, but just in case, it should probably be checked.